### PR TITLE
Add espeak and ffmpeg to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
+FROM jrottenberg/ffmpeg:3.4-scratch as ffmpeg
+
 FROM php:alpine
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
+RUN apk --update add espeak
+
+COPY --from=ffmpeg /bin/ffmpeg /usr/local/bin/ffmpeg
 COPY . /app/
 WORKDIR /app
 


### PR DESCRIPTION
In order to use the ffmpeg binary in the image, this commit utilizes
multi-stage builds to copy it into the image.  This commit also adds the
espeak cli tool to the image.